### PR TITLE
Lock libarchive on 1.x

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,4 @@ version          "0.3.5"
 
 supports "ubuntu"
 
-depends "libarchive"
+depends "libarchive", "~> 1.0"


### PR DESCRIPTION
Libarchive 2.x requires Chef 14 (https://github.com/chef-cookbooks/libarchive/#requirements) while we are still running 12 (https://github.com/gatemedia/gmp-os/blob/95a4561013dbe6e26056bee8397bdd909dc0f4f9/iso_config/preseed/install.sh#L24)