### PR TITLE
Lock octokit at 4.21.0

### DIFF
--- a/providers/asset.rb
+++ b/providers/asset.rb
@@ -18,10 +18,12 @@ action :download do
   if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
     chef_gem "octokit" do
       compile_time true
+      version "4.21.0"
     end
   else
     chef_gem "octokit" do
       action :nothing
+      version "4.21.0"
     end.run_action(:install)
   end
 


### PR DESCRIPTION
Octokit 4.22.0 not compatible with legacy faraday versions.

see https://github.com/octokit/octokit.rb/issues/1391
see https://github.com/octokit/octokit.rb/issues/1392
see https://github.com/octokit/octokit.rb/issues/1388

fix gatemedia/gmp-os#218